### PR TITLE
setNonBlockIfNeeded

### DIFF
--- a/System/Systemd/Daemon.hs
+++ b/System/Systemd/Daemon.hs
@@ -252,7 +252,9 @@ getActivatedSocketsWithNames = runMaybeT $ do
           fam  <- socketFamily fd
           typ  <- socketType fd
           stat <- socketStatus fd
-          liftIO $ mkSocket fd fam typ defaultProtocol stat
+          liftIO $ do
+            setNonBlockIfNeeded fd
+            mkSocket fd fam typ defaultProtocol stat
 
 socketFamily :: CInt -> MaybeT IO Family
 socketFamily fd = do

--- a/systemd.cabal
+++ b/systemd.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                systemd
-version:             1.1.2
+version:             1.2.0
 synopsis:            Systemd facilities (Socket activation, Notify)
 description:         A module for Systemd facilities.
 homepage:            https://github.com/erebe/systemd


### PR DESCRIPTION
[Documentation of mkSocket](https://www.stackage.org/haddock/lts-13.21/network-2.8.0.1/Network-Socket.html#v:mkSocket) advises that a call to `setNonBlockIfNeeded` might be neccessary on some systems and that is it not harmful on systems where it is not.

I have observed usecases that were previously broken because of this (specifically all semi-recent versions of Warp).