### PR TITLE
Reflect breaking library changes in network 3.1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist
+dist-newstyle
+.ghc.environment.*
 cabal-dev
 *.o
 *.hi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Haskell implementation for systemd
+# Haskell implementation for systemd
 
 Systemd offers some functionnalities to developpers for creating daemons process
 

--- a/systemd.cabal
+++ b/systemd.cabal
@@ -15,7 +15,7 @@ category:            System
 build-type:          Simple
 extra-source-files:  README.md
 stability:           stable
-cabal-version:       >=1.10
+cabal-version:       >=2.0
 source-repository head
     type: git
     location: https://github.com/erebe/systemd
@@ -27,7 +27,7 @@ library
   build-depends:       base == 4.* ,
                        unix >= 2.5,
                        transformers >= 0.3,
-                       network >= 2.6.3.2,
+                       network ^>=3.1.0.0,
                        bytestring >= 0.10
 
   default-language:    Haskell2010
@@ -37,7 +37,7 @@ test-suite daemon-test
    type:                exitcode-stdio-1.0
    main-is:             Main.hs
    build-depends:       base == 4.*,
-                        network >= 2.6.3.2,
+                        network ^>=3.1.0.0,
                         unix >= 2.5,
                         systemd
    default-language:    Haskell2010

--- a/systemd.cabal
+++ b/systemd.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                systemd
-version:             1.2.0
+version:             1.3.0
 synopsis:            Systemd facilities (Socket activation, Notify)
 description:         A module for Systemd facilities.
 homepage:            https://github.com/erebe/systemd

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,15 +2,15 @@
 import System.Systemd.Daemon
 import Control.Monad
 import Control.Concurrent
-import Network
 
+import Network.Socket
 import System.IO
 import Data.Char
 import System.Posix.Env as Ev
 
 
 apF :: Show w => w -> IO ()
-apF = appendFile "/home/erebe/log" . (++ "\n") . show
+apF = appendFile "/tmp/log" . (++ "\n") . show
 
 test :: IO ()
 test = do
@@ -24,8 +24,10 @@ test = do
   apF "totot"
 
   threadDelay $ 1000000 * 20
-  s <- listenOn (PortNumber 1213)
-  s' <- listenOn (PortNumber 1214)
+  s <- socket AF_INET Stream defaultProtocol
+  s' <- socket AF_INET Stream defaultProtocol
+  listen s 1213
+  listen s' 1214
 
   x <- storeFd s
   apF x


### PR DESCRIPTION
`network` 3.0.0.0 and 3.1.0.0 broke a lot of the API this package used, but also simplified things a lot. This fixes all compilation errors. Note that haven't tested this change yet, since I am only just now implementing systemd support in my daemon, so this is currently mostly for your information. I will get back to you in the next few days when I have tested the change, also feel free to test it yourself!

Edit: We have to use the `fdSocket` function which is already depreacated in 3.1.0.0. :neutral_face: 